### PR TITLE
Added ASUS USB-AX67 Nano

### DIFF
--- a/rtw8852bu.c
+++ b/rtw8852bu.c
@@ -50,6 +50,8 @@ static const struct usb_device_id rtw_8852bu_id_table[] = {
 	  .driver_info = (kernel_ulong_t)&rtw89_8852bu_info },
 	{ USB_DEVICE_AND_INTERFACE_INFO(0x0b05, 0x1a62, 0xff, 0xff, 0xff),
 	  .driver_info = (kernel_ulong_t)&rtw89_8852bu_info },
+	{ USB_DEVICE_AND_INTERFACE_INFO(0x0b05, 0x1cb6, 0xff, 0xff, 0xff),
+	  .driver_info = (kernel_ulong_t)&rtw89_8852bu_info },
 	{ USB_DEVICE_AND_INTERFACE_INFO(0x0db0, 0x6931, 0xff, 0xff, 0xff),
 	  .driver_info = (kernel_ulong_t)&rtw89_8852bu_info },
 	{ USB_DEVICE_AND_INTERFACE_INFO(0x2001, 0x3327, 0xff, 0xff, 0xff),


### PR DESCRIPTION
Confirmed AX57 now works with this driver
  *-network
       description: Wireless interface
       physical id: b
       bus info: usb@1:3
       logical name: wlxa0ad9f70287a
       serial: a0:ad:9f:70:28:7a
       capabilities: ethernet physical wireless
       configuration: broadcast=yes driver=rtw89_8852bu_git driverversion=6.8.0-87-generic firmware=N/A ip=192.168.1.237 link=yes multicast=yes wireless=IEEE 802.11
