### PR TITLE
rtw89_8922au: add USB ID for TP-Link BE3600U

### DIFF
--- a/rtw8922au.c
+++ b/rtw8922au.c
@@ -49,6 +49,8 @@ static const struct usb_device_id rtw_8922au_id_table[] = {
 	  .driver_info = (kernel_ulong_t)&rtw89_8922au_info },
 	{ USB_DEVICE_AND_INTERFACE_INFO(0x7392, 0x3822, 0xff, 0xff, 0xff),
 	  .driver_info = (kernel_ulong_t)&rtw89_8922au_info },
+	{ USB_DEVICE_AND_INTERFACE_INFO(0x37ad, 0x0100, 0xff, 0xff, 0xff),
+	  .driver_info = (kernel_ulong_t)&rtw89_8922au_info }, /* TP-Link BE3600U */
 	{},
 };
 MODULE_DEVICE_TABLE(usb, rtw_8922au_id_table);


### PR DESCRIPTION
The TP-Link BE3600U WiFi 7 adapter uses the RTL8922AU chipset but isn't recognized by the driver due to a missing USB ID.

  ### Device Info
  Bus 004 Device 004: ID 37ad:0100 Realtek 802.11be WLAN Adapter

  - **Product**: TP-Link BE3600U
  - **USB ID**: `37ad:0100`
  - **Chipset**: RTL8922AU

  ### Fix

  Adding the following entry to `rtw8922au.c` in the `rtw89_8922au_id_table` makes the adapter work:

  ```c
  { USB_DEVICE_AND_INTERFACE_INFO(0x37ad, 0x0100, 0xff, 0xff, 0xff),
    .driver_info = (kernel_ulong_t)&rtw89_8922au_info }, /* TP-Link BE3600U */

  Environment

  - Kernel: 6.18.2-arch2-1
  - Distro: Arch Linux
  - Note: Requires usb_modeswitch as the adapter initially presents as a CD-ROM device (0bda:1a2b)

  Status

  Tested and working - connected to WiFi successfully.
  ```