### PR TITLE
usb: fix mac80211 TX flow control contract violation

### DIFF
--- a/usb.h
+++ b/usb.h
@@ -21,6 +21,9 @@
 #define RTW89_MAX_BULKIN_NUM		2
 #define RTW89_MAX_BULKOUT_NUM		7
 
+/* TX flow control: max in-flight URBs per channel */
+#define RTW89_USB_MAX_TX_URBS_PER_CH	32
+
 struct rtw89_usb_info {
 	u32 usb_host_request_2;
 	u32 usb_wlan0_1;
@@ -67,6 +70,9 @@ struct rtw89_usb {
 	struct usb_anchor tx_submitted;
 
 	struct sk_buff_head tx_queue[RTW89_TXCH_NUM];
+
+	/* TX flow control: track in-flight URBs per channel */
+	atomic_t tx_inflight[RTW89_TXCH_NUM];
 };
 
 static inline struct rtw89_usb *rtw89_usb_priv(struct rtw89_dev *rtwdev)


### PR DESCRIPTION
## Summary

This restores correct mac80211 TX backpressure semantics for rtw89 USB.

## The Bug

`rtw89_usb_ops_check_and_reclaim_tx_resource()` returns a hardcoded placeholder:

```c
return 42; /* TODO some kind of calculation? */
```

This violates mac80211's flow control contract, causing uncontrolled URB accumulation under sustained TX load.

## The Fix

Add per-channel atomic counters (`tx_inflight[]`) that track in-flight URBs:

- Increment before `usb_submit_urb()` with rollback on failure
- Decrement in completion callback
- Return `(MAX_URBS - inflight)` to mac80211, or 0 when at capacity
- Exclude firmware command channel (CH12) from tracking

## Testing

Tested on D-Link DWA-X1850 (RTL8832AU, USB ID 2001:3321), Fedora 43, kernel 6.18.3.

| Test | Result |
|------|--------|
| 100-iteration stress (flood ping) | PASS |
| 50-iteration teardown (rmmod/modprobe under load) | PASS |
| 10x hot-unplug during active TX | PASS |
| 30-minute soak | PASS, counters balanced at idle |