### PR TITLE
wifi: rtw89: phy: increase RF calibration timeouts for USB transport

### DIFF
--- a/phy.c
+++ b/phy.c
@@ -4029,6 +4029,14 @@ int rtw89_phy_rfk_report_wait(struct rtw89_dev *rtwdev, const char *rfk_name,
 	struct rtw89_rfk_wait_info *wait = &rtwdev->rfk_wait;
 	unsigned long time_left;
 
+	/*
+	 * USB transport adds latency to H2C/C2H round-trips, so RF
+	 * calibrations take longer than on PCIe. Apply a 4x multiplier
+	 * to avoid spurious timeouts.
+	 */
+	if (rtwdev->hci.type == RTW89_HCI_TYPE_USB)
+		ms *= 4;
+
 	/* Since we can't receive C2H event during SER, use a fixed delay. */
 	if (test_bit(RTW89_FLAG_SER_HANDLING, rtwdev->flags)) {
 		fsleep(1000 * ms / 2);


### PR DESCRIPTION
## Summary

USB transport adds significant latency to RF calibration H2C/C2H round-trips compared to PCIe, causing `failed to wait RF DACK`, `failed to wait RF TSSI` and similar errors on USB adapters like RTL8922AU.

This patch applies a **4x timeout multiplier** in `rtw89_phy_rfk_report_wait()` when the device uses USB transport. All RF calibrations (DACK, RX_DCK, TSSI, TXGAPK, IQK, DPK, PRE_NTFY) benefit without changing any call sites or PCIe timeout values.

## Upstream status

**Accepted for merge into wireless-next** by Ping-Ke Shih (Realtek rtw89 maintainer) after the merge window (~1.5 weeks from 2026-04-17):

- v3 (final): https://lore.kernel.org/linux-wireless/20260416045536.817930-1-loukot@gmail.com/
- v2: https://lore.kernel.org/linux-wireless/20260415111339.453602-1-loukot@gmail.com/
- v1 + Ping-Ke's review: https://lore.kernel.org/linux-wireless/20260410080017.82946-1-loukot@gmail.com/

This PR mirrors the upstream v3 commit exactly (commit message, code, and trailers).

## Changes since v2 (PR) / v1 (upstream)

1. **Commit message reworded** per Ping-Ke review: use "condition" instead of "bug", acknowledge hardware factors in calibration timing rather than asserting I/O bound, remove v1 reference from permanent changelog.
2. **Added Tested-by tags** from Devin Wittmayer across 5 adapters (RTL8922AU, RTL8852AU x2, RTL8852BU, RTL8852CU) on Framework 13 + Fedora 43 and Raspberry Pi 5 + Pi OS.
3. **Added Reported-by + Link** for independent xHCI crash evidence.
4. **Added Acked-by** from Ping-Ke Shih.
5. **Dropped patch 2/2** (non-fatal timeout handling) — return code is discarded by all 8922a callers, and the one 8922d caller uses it for TSSI fallback.

## Testing

- **Hardware**: RTL8922AU, RTL8852AU, RTL8852BU, RTL8852CU (5 adapters across 2 testers)
- **Method**: 25 connect/disconnect cycles + stress-ng matrix (CPU/memory/combined)
- **Result**: zero calibration failures; DACK stable at 71ms under all conditions

See also: #78 — independent confirmation with 30-min iperf3 soak (25→0 dmesg errors) and xHCI hard lockup evidence.