### PR TITLE
Fedora integration - dkms package, Claude Sonnet

### DIFF
--- a/fedora/Makefile
+++ b/fedora/Makefile
@@ -1,9 +1,28 @@
 # Use bash syntax, mitigates dash's printf on Debian
 SHELL := /usr/bin/bash
 
+REQUIRED_PKGS := rpmdevtools git-core kernel-devel-matched
+
 .PHONY: all
 
 all:
-	git -C .. archive --format=tar.gz --prefix=rtw89-7.1/ HEAD > ~/rpmbuild/SOURCES/rtw89-7.1.tar.gz
+	@for i in $(REQUIRED_PKGS); do \
+		rpm -q $$i >/dev/null || { \
+			printf "Missing '%s', install with:\n\tsudo dnf install %s\n" "$$i" "$(REQUIRED_PKGS)"; \
+			exit 1; \
+		}; \
+	done
+	rpmdev-setuptree
+	# /usr/src has no .git, so replace the git rev-parse call with the
+	# HEAD commit hash captured now, before packing the source tarball.
+	# Also strip the deprecated CLEAN directive from dkms.conf.
+	commit=$$(git -C .. rev-parse HEAD) && \
+	tmpdir=$$(mktemp -d) && \
+		trap "rm -rf $$tmpdir" EXIT && \
+		git -C .. archive --format=tar --prefix=rtw89-7.1/ HEAD | tar -C "$$tmpdir" -xf - && \
+		sed -i 's|$$(shell git --git-dir=$$(src)/\.git rev-parse HEAD)|'"$$commit"'|' "$$tmpdir/rtw89-7.1/Makefile" && \
+		sed -i '/^CLEAN=/d' "$$tmpdir/rtw89-7.1/dkms.conf" && \
+		rm -rf "$$tmpdir/rtw89-7.1/firmware" "$$tmpdir/rtw89-7.1/hostapd" "$$tmpdir/rtw89-7.1/fedora" && \
+		tar -C "$$tmpdir" -czf ~/rpmbuild/SOURCES/rtw89-7.1.tar.gz rtw89-7.1
 	rpmbuild -ba rtw89-dkms.spec
 	@printf '\nNow run sudo dnf install ~/rpmbuild/RPMS/noarch/rtw89-dkms-*.noarch.rpm\n\n'

--- a/fedora/Makefile
+++ b/fedora/Makefile
@@ -1,0 +1,9 @@
+# Use bash syntax, mitigates dash's printf on Debian
+SHELL := /usr/bin/bash
+
+.PHONY: all
+
+all:
+	git -C .. archive --format=tar.gz --prefix=rtw89-7.1/ HEAD > ~/rpmbuild/SOURCES/rtw89-7.1.tar.gz
+	rpmbuild -ba rtw89-dkms.spec
+	@printf '\nNow run sudo dnf install ~/rpmbuild/RPMS/noarch/rtw89-dkms-*.noarch.rpm\n\n'

--- a/fedora/README.md
+++ b/fedora/README.md
@@ -1,0 +1,29 @@
+# RTW89 Fedora DKMS package
+
+This was created with the assistance of Claude Oppus 4.6.
+
+## Summary of what was created
+
+- [rtw89-dkms.spec](fedora/rtw89-dkms.spec).
+
+## What the package installs:
+
+|               Path               |                 Content                 |
+|----------------------------------|-----------------------------------------|
+| /usr/src/rtw89-7.1/              | 110 source files + Makefile + dkms.conf |
+| /usr/lib/firmware/rtw89/*.bin    | 6 firmware binaries                     |
+| /etc/modprobe.d/rtw89.conf       | blacklists + driver options             |
+| /etc/modprobe.d/usb_storage.conf | USB quirks                              |
+
+## Install
+
+To rebuild the tarball after new commits (bump Release: in the spec too):
+```
+git -C .. archive --format=tar.gz --prefix=rtw89-7.1/ HEAD > ~/rpmbuild/SOURCES/rtw89-7.1.tar.gz
+rpmbuild -ba rtw89-dkms.spec
+sudo dnf install ~/rpmbuild/RPMS/noarch/rtw89-dkms-*.noarch.rpm
+```
+Verify it worked:
+```
+dkms status   # verify: rtw89/7.1, <kernel>: installed
+```

--- a/fedora/README.md
+++ b/fedora/README.md
@@ -10,7 +10,7 @@ This was created with the assistance of Claude Opus 4.6.
 
 | Path                       | Content                                 |
 |----------------------------|-----------------------------------------|
-| /usr/src/rtw89-7.1/        | 110 source files + Makefile + dkms.conf |
+| /usr/src/rtw89-7.1/        | 102 source files + Makefile + dkms.conf |
 | /etc/modprobe.d/rtw89.conf | blacklists + driver options             |
 
 ## Install

--- a/fedora/README.md
+++ b/fedora/README.md
@@ -1,29 +1,42 @@
 # RTW89 Fedora DKMS package
 
-This was created with the assistance of Claude Oppus 4.6.
+This was created with the assistance of Claude Opus 4.6.
 
 ## Summary of what was created
 
-- [rtw89-dkms.spec](fedora/rtw89-dkms.spec).
+- [rtw89-dkms.spec](rtw89-dkms.spec).
 
 ## What the package installs:
 
-|               Path               |                 Content                 |
-|----------------------------------|-----------------------------------------|
-| /usr/src/rtw89-7.1/              | 110 source files + Makefile + dkms.conf |
-| /usr/lib/firmware/rtw89/*.bin    | 6 firmware binaries                     |
-| /etc/modprobe.d/rtw89.conf       | blacklists + driver options             |
-| /etc/modprobe.d/usb_storage.conf | USB quirks                              |
+| Path                       | Content                                 |
+|----------------------------|-----------------------------------------|
+| /usr/src/rtw89-7.1/        | 110 source files + Makefile + dkms.conf |
+| /etc/modprobe.d/rtw89.conf | blacklists + driver options             |
 
 ## Install
 
-To rebuild the tarball after new commits (bump Release: in the spec too):
+First install the dependencies to build the rpm package:
+
+```bash
+sudo dnf install rpmdevtools make git-core kernel-devel-matched
 ```
-git -C .. archive --format=tar.gz --prefix=rtw89-7.1/ HEAD > ~/rpmbuild/SOURCES/rtw89-7.1.tar.gz
-rpmbuild -ba rtw89-dkms.spec
+
+Then (re)build the package:
+
+```bash
+rm -fv ~/rpmbuild/RPMS/noarch/rtw89-dkms-*.noarch.rpm ~/rpmbuild/SRPMS/rtw89-dkms-*.src.rpm
+make
 sudo dnf install ~/rpmbuild/RPMS/noarch/rtw89-dkms-*.noarch.rpm
 ```
+
 Verify it worked:
+
+```bash
+dkms status   # verify: rtw89/7.1, $(uname -r), $(uname -m): installed
 ```
-dkms status   # verify: rtw89/7.1, <kernel>: installed
+
+Check if the git commit got embedded properly:
+
+```bash
+xzcat /usr/lib/modules/$(uname -r)/extra/rtw89_core_git.ko.xz | grep -a "git commit"
 ```

--- a/fedora/rtw89-dkms.spec
+++ b/fedora/rtw89-dkms.spec
@@ -6,7 +6,7 @@
 
 Name:           %{dkms_name}-dkms
 Version:        %{dkms_version}
-Release:        2%{?dist}
+Release:        3%{?dist}
 Summary:        Out-of-tree DKMS driver for Realtek rtw89 WiFi chips
 License:        GPL-2.0-only OR BSD-3-Clause
 URL:            https://github.com/morrownr/rtw89
@@ -46,17 +46,9 @@ sed -i \
 install -d %{buildroot}%{_usrsrc}/%{dkms_name}-%{dkms_version}
 cp -a *.c *.h Makefile dkms.conf %{buildroot}%{_usrsrc}/%{dkms_name}-%{dkms_version}/
 
-# 2. Firmware -> /usr/lib/firmware/rtw89/
-install -d %{buildroot}/usr/lib/firmware/rtw89
-install -m 0644 firmware/*.bin %{buildroot}/usr/lib/firmware/rtw89/
-
-# 3. License file
-install -Dm 0644 firmware/LICENCE.rtlwifi_firmware.txt \
-    %{buildroot}%{_licensedir}/%{name}/LICENCE.rtlwifi_firmware.txt
-
-# 4. modprobe config -> /etc/modprobe.d/
+# 2. modprobe config -> /etc/modprobe.d/
 install -Dm 0644 rtw89.conf       %{buildroot}%{_sysconfdir}/modprobe.d/rtw89.conf
-install -Dm 0644 usb_storage.conf %{buildroot}%{_sysconfdir}/modprobe.d/usb_storage.conf
+# usb_storage.conf is only needed for kernels < 6.17, fedora 43 and 44 use kernel-6.19+.
 
 %post
 # Register with DKMS; --rpm_safe_upgrade removes old version on upgrade.
@@ -70,19 +62,21 @@ if [ "$1" -eq 0 ]; then
 fi
 
 %files
-%license %{_licensedir}/%{name}/LICENCE.rtlwifi_firmware.txt
 %dir %{_usrsrc}/%{dkms_name}-%{dkms_version}
 %{_usrsrc}/%{dkms_name}-%{dkms_version}/*.c
 %{_usrsrc}/%{dkms_name}-%{dkms_version}/*.h
 %{_usrsrc}/%{dkms_name}-%{dkms_version}/Makefile
 %{_usrsrc}/%{dkms_name}-%{dkms_version}/dkms.conf
-%{_prefix}/lib/firmware/rtw89/*.bin
 %config(noreplace) %{_sysconfdir}/modprobe.d/rtw89.conf
-%config(noreplace) %{_sysconfdir}/modprobe.d/usb_storage.conf
 
 %changelog
+* Sat Apr 18 2026 Doncho Gunchev <dgunchev@gmail.com> - 7.1-3
+As advised by a5a5aa555oo:
+- Drop firmware files: realtek-firmware provided by Fedora is up-to-date
+- Drop usb_storage.conf: not needed on kernel 6.17+, F43 shipped with 6.17
+
 * Sat Apr 18 2026 Doncho Gunchev <dgunchev@gmail.com> - 7.1-2
 - Cleanup, simplify.
 
-* Fri Apr 17 2026 Claude Opus <claude@claude.ai> - 7.1-1
+* Fri Apr 17 2026 Claude Sonnet <claude@claude.ai> - 7.1-1
 - Initial package based on morrownr/rtw89 version 7.1

--- a/fedora/rtw89-dkms.spec
+++ b/fedora/rtw89-dkms.spec
@@ -1,0 +1,88 @@
+# git -C .. archive --format=tar.gz --prefix=rtw89-7.1/ HEAD > ~/rpmbuild/SOURCES/rtw89-7.1.tar.gz
+# rpmbuild -ba rtw89-dkms.spec
+
+%global dkms_name    rtw89
+%global dkms_version 7.1
+
+Name:           %{dkms_name}-dkms
+Version:        %{dkms_version}
+Release:        2%{?dist}
+Summary:        Out-of-tree DKMS driver for Realtek rtw89 WiFi chips
+License:        GPL-2.0-only OR BSD-3-Clause
+URL:            https://github.com/morrownr/rtw89
+Source0:        %{dkms_name}-%{dkms_version}.tar.gz
+BuildArch:      noarch
+
+BuildRequires:  sed
+
+Requires:       dkms
+Requires:       kernel-devel
+Requires:       gcc
+Requires:       make
+Recommends:     realtek-firmware
+
+%description
+Out-of-tree DKMS kernel modules for Realtek rtw89-series WiFi adapters
+(RTW8851B, RTW8852A/B/BT/C, RTW8922A and their USB/PCIe variants).
+
+Modules are built automatically for every installed kernel >= 6.6 via DKMS.
+Module names carry a _git suffix (e.g. rtw89_core_git) to avoid clashing
+with the in-kernel rtw89 driver. Blacklist rules in /etc/modprobe.d/ suppress
+the in-kernel modules so only this driver loads.
+
+%prep
+%setup -q -n %{dkms_name}-%{dkms_version}
+# Fix GIT_COMMIT: /usr/src has no .git; replace the git rev-parse call with
+# the static package version string so the DKMS build does not fail.
+sed -i \
+    's|$(shell git --git-dir=$(src)/\.git rev-parse HEAD)|%{dkms_version}|' \
+    Makefile
+
+%build
+# No compilation here; DKMS builds modules at kernel install time.
+
+%install
+# 1. DKMS source tree -> /usr/src/rtw89-7.1/
+install -d %{buildroot}%{_usrsrc}/%{dkms_name}-%{dkms_version}
+cp -a *.c *.h Makefile dkms.conf %{buildroot}%{_usrsrc}/%{dkms_name}-%{dkms_version}/
+
+# 2. Firmware -> /usr/lib/firmware/rtw89/
+install -d %{buildroot}/usr/lib/firmware/rtw89
+install -m 0644 firmware/*.bin %{buildroot}/usr/lib/firmware/rtw89/
+
+# 3. License file
+install -Dm 0644 firmware/LICENCE.rtlwifi_firmware.txt \
+    %{buildroot}%{_licensedir}/%{name}/LICENCE.rtlwifi_firmware.txt
+
+# 4. modprobe config -> /etc/modprobe.d/
+install -Dm 0644 rtw89.conf       %{buildroot}%{_sysconfdir}/modprobe.d/rtw89.conf
+install -Dm 0644 usb_storage.conf %{buildroot}%{_sysconfdir}/modprobe.d/usb_storage.conf
+
+%post
+# Register with DKMS; --rpm_safe_upgrade removes old version on upgrade.
+dkms add --rpm_safe_upgrade -m %{dkms_name} -v %{dkms_version} &>/dev/null || :
+dkms autoinstall -m %{dkms_name} -v %{dkms_version} &>/dev/null || :
+
+%preun
+# Only deregister on final removal ($1==0), not on upgrade ($1==1).
+if [ "$1" -eq 0 ]; then
+    dkms remove --rpm_safe_upgrade -m %{dkms_name} -v %{dkms_version} --all &>/dev/null || :
+fi
+
+%files
+%license %{_licensedir}/%{name}/LICENCE.rtlwifi_firmware.txt
+%dir %{_usrsrc}/%{dkms_name}-%{dkms_version}
+%{_usrsrc}/%{dkms_name}-%{dkms_version}/*.c
+%{_usrsrc}/%{dkms_name}-%{dkms_version}/*.h
+%{_usrsrc}/%{dkms_name}-%{dkms_version}/Makefile
+%{_usrsrc}/%{dkms_name}-%{dkms_version}/dkms.conf
+%{_prefix}/lib/firmware/rtw89/*.bin
+%config(noreplace) %{_sysconfdir}/modprobe.d/rtw89.conf
+%config(noreplace) %{_sysconfdir}/modprobe.d/usb_storage.conf
+
+%changelog
+* Sat Apr 18 2026 Doncho Gunchev <dgunchev@gmail.com> - 7.1-2
+- Cleanup, simplify.
+
+* Fri Apr 17 2026 Claude Opus <claude@claude.ai> - 7.1-1
+- Initial package based on morrownr/rtw89 version 7.1

--- a/fedora/rtw89-dkms.spec
+++ b/fedora/rtw89-dkms.spec
@@ -1,25 +1,17 @@
-# git -C .. archive --format=tar.gz --prefix=rtw89-7.1/ HEAD > ~/rpmbuild/SOURCES/rtw89-7.1.tar.gz
-# rpmbuild -ba rtw89-dkms.spec
-
-%global dkms_name    rtw89
+%global dkms_name rtw89
 %global dkms_version 7.1
 
 Name:           %{dkms_name}-dkms
 Version:        %{dkms_version}
-Release:        3%{?dist}
+Release:        5%{?dist}
 Summary:        Out-of-tree DKMS driver for Realtek rtw89 WiFi chips
 License:        GPL-2.0-only OR BSD-3-Clause
 URL:            https://github.com/morrownr/rtw89
 Source0:        %{dkms_name}-%{dkms_version}.tar.gz
 BuildArch:      noarch
 
-BuildRequires:  sed
-
 Requires:       dkms
-Requires:       kernel-devel
-Requires:       gcc
-Requires:       make
-Recommends:     realtek-firmware
+Requires:       realtek-firmware
 
 %description
 Out-of-tree DKMS kernel modules for Realtek rtw89-series WiFi adapters
@@ -32,14 +24,12 @@ the in-kernel modules so only this driver loads.
 
 %prep
 %setup -q -n %{dkms_name}-%{dkms_version}
-# Fix GIT_COMMIT: /usr/src has no .git; replace the git rev-parse call with
-# the static package version string so the DKMS build does not fail.
-sed -i \
-    's|$(shell git --git-dir=$(src)/\.git rev-parse HEAD)|%{dkms_version}|' \
-    Makefile
 
 %build
 # No compilation here; DKMS builds modules at kernel install time.
+
+%check
+# No check here.
 
 %install
 # 1. DKMS source tree -> /usr/src/rtw89-7.1/
@@ -51,15 +41,14 @@ install -Dm 0644 rtw89.conf       %{buildroot}%{_sysconfdir}/modprobe.d/rtw89.co
 # usb_storage.conf is only needed for kernels < 6.17, fedora 43 and 44 use kernel-6.19+.
 
 %post
-# Register with DKMS; --rpm_safe_upgrade removes old version on upgrade.
-dkms add --rpm_safe_upgrade -m %{dkms_name} -v %{dkms_version} &>/dev/null || :
-dkms autoinstall -m %{dkms_name} -v %{dkms_version} &>/dev/null || :
+# Register with DKMS; --rpm_safe_upgrade removes old version on upgrade:
+dkms add -m %{dkms_name} -v %{dkms_version} --rpm_safe_upgrade || :
+# Rebuild and make available for the currently running kernel:
+dkms build -m %{dkms_name} -v %{dkms_version} -q --force
+dkms install -m %{dkms_name} -v %{dkms_version} -q --force
 
 %preun
-# Only deregister on final removal ($1==0), not on upgrade ($1==1).
-if [ "$1" -eq 0 ]; then
-    dkms remove --rpm_safe_upgrade -m %{dkms_name} -v %{dkms_version} --all &>/dev/null || :
-fi
+dkms remove -m %{dkms_name} -v %{dkms_version} -q --all --rpm_safe_upgrade
 
 %files
 %dir %{_usrsrc}/%{dkms_name}-%{dkms_version}
@@ -70,13 +59,5 @@ fi
 %config(noreplace) %{_sysconfdir}/modprobe.d/rtw89.conf
 
 %changelog
-* Sat Apr 18 2026 Doncho Gunchev <dgunchev@gmail.com> - 7.1-3
-As advised by a5a5aa555oo:
-- Drop firmware files: realtek-firmware provided by Fedora is up-to-date
-- Drop usb_storage.conf: not needed on kernel 6.17+, F43 shipped with 6.17
-
-* Sat Apr 18 2026 Doncho Gunchev <dgunchev@gmail.com> - 7.1-2
-- Cleanup, simplify.
-
-* Fri Apr 17 2026 Claude Sonnet <claude@claude.ai> - 7.1-1
+* Tue Apr 21 2026 Doncho Nikolaev Gunchev <dgunchev@gmail.com> - 7.1-5
 - Initial package based on morrownr/rtw89 version 7.1


### PR DESCRIPTION
Hi, are you interested in Fedora integration? I created this for myself, worked on Fedora 43 and is working on 44 beta now, two hours of zoom worked well. Here is the [copr build](https://copr.fedorainfracloud.org/coprs/dgunchev/dgunchev/build/10344408/).

I got [COMFAST WiFi7 USB Adapter BE6500](https://www.aliexpress.com/item/1005009069752506.html) and [WiFi 7/WiFi 6E BE6500 AX5400 Wireless Adapter](https://www.aliexpress.com/item/1005007702601704.html) from aliexpress and none works without this new driver. No idea which firmware got loaded though (from realtek-firmware-20260309-1.fc44.noarch or the dkms).