### PR TITLE
README: dedupe step number in Installation Guide

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ git, make, gcc, kernel-headers, dkms and mokutil (dkms and mokutil are optional.
    sudo make cleanup_target_system
    ```
 
-3. Build and install the driver
+4. Build and install the driver
 
    * _via dkms (Recommended especially if Secure Boot is enabled in your system)_
 
@@ -55,20 +55,20 @@ git, make, gcc, kernel-headers, dkms and mokutil (dkms and mokutil are optional.
      make clean modules && sudo make install
      ```
 
-4. Install the firmware necessary for the driver
+5. Install the firmware necessary for the driver
 
    ```
    sudo make install_fw
    ```
 
-5. Copy the configuration file `rtw89.conf` to /etc/modprobe.d/
+6. Copy the configuration file `rtw89.conf` to /etc/modprobe.d/
    ```
    sudo cp -v rtw89.conf /etc/modprobe.d/
    ```
    
    Note: The above step will blacklist in-kernel drivers that can conflict with drivers in this repo.
 
-6. Enroll the MOK (Machine Owner Key). This is needed **ONLY IF** [Secure Boot](https://wiki.debian.org/SecureBoot) is enabled in your system. Please see [this guide](https://github.com/dell/dkms?tab=readme-ov-file#secure-boot) for details.
+7. Enroll the MOK (Machine Owner Key). This is needed **ONLY IF** [Secure Boot](https://wiki.debian.org/SecureBoot) is enabled in your system. Please see [this guide](https://github.com/dell/dkms?tab=readme-ov-file#secure-boot) for details.
 
    ```
    sudo mokutil --import /var/lib/dkms/mok.pub


### PR DESCRIPTION
Step `3.` appears twice in the Installation Guide source: once for `cleanup_target_system`, once for `Build and install the driver`.

The rendered README on github.com is fine because CommonMark auto-renumbers ordered lists in HTML, but the raw `.md` source reads `1, 2, 3, 3, 4, 5, 6`, which is confusing for tools and agents that consume the markdown directly (terminal viewers, AI install assistants that summarise the steps for end users, RAG indexes over raw docs).

This patch only renumbers the affected lines:

- `3. Build and install the driver` → `4.`
- `4. Install the firmware...` → `5.`
- `5. Copy the configuration file rtw89.conf...` → `6.`
- `6. Enroll the MOK...` → `7.`

No content or wording changes; rendered output on github.com is unchanged for human readers.