### PR TITLE
feat(fedora): add akmod/kmod packaging for rpm-ostree systems

### DIFF
--- a/fedora/Makefile
+++ b/fedora/Makefile
@@ -3,21 +3,28 @@ SHELL := /usr/bin/bash
 
 VERSION := $(shell grep '^PACKAGE_VERSION=' ../dkms.conf | cut -d'"' -f2)
 
-REQUIRED_PKGS := rpmdevtools git-core kernel-devel-matched
+# Common build tooling.
+REQUIRED_PKGS     := rpmdevtools git-core
+# DKMS path additionally needs a matched kernel-devel; the akmod/kmod path
+# needs kmodtool + akmods (and kernel-devel only when building binary kmods).
+DKMS_REQUIRED_PKGS  := $(REQUIRED_PKGS) kernel-devel-matched
+KMOD_REQUIRED_PKGS  := $(REQUIRED_PKGS) kmodtool akmods kernel-devel-matched
 
-.PHONY: all
+.PHONY: all akmod kmod dkms tarball check-kmod-deps check-dkms-deps
 
-all:
-	@for i in $(REQUIRED_PKGS); do \
-		rpm -q $$i >/dev/null || { \
-			printf "Missing '%s', install with:\n\tsudo dnf install %s\n" "$$i" "$(REQUIRED_PKGS)"; \
-			exit 1; \
-		}; \
-	done
+# Default target builds the akmod package, which is what works on immutable /
+# rpm-ostree systems (Fedora Kinoite, Silverblue, ...).
+all: akmod
+
+# ---------------------------------------------------------------------------
+# Shared: build the source tarball into ~/rpmbuild/SOURCES/.
+#
+# /usr/src has no .git, so replace the git rev-parse call in the driver
+# Makefile with the HEAD commit hash captured now, before packing the tarball.
+# Also strip the deprecated CLEAN directive from dkms.conf.
+# ---------------------------------------------------------------------------
+tarball:
 	rpmdev-setuptree
-	# /usr/src has no .git, so replace the git rev-parse call with the
-	# HEAD commit hash captured now, before packing the source tarball.
-	# Also strip the deprecated CLEAN directive from dkms.conf.
 	commit=$$(git -C .. rev-parse HEAD) && \
 	tmpdir=$$(mktemp -d) && \
 		trap "rm -rf $$tmpdir" EXIT && \
@@ -26,5 +33,61 @@ all:
 		sed -i '/^CLEAN=/d' "$$tmpdir/rtw89-$(VERSION)/dkms.conf" && \
 		rm -rf "$$tmpdir/rtw89-$(VERSION)/firmware" "$$tmpdir/rtw89-$(VERSION)/hostapd" "$$tmpdir/rtw89-$(VERSION)/fedora" && \
 		tar -C "$$tmpdir" -czf ~/rpmbuild/SOURCES/rtw89-$(VERSION).tar.gz rtw89-$(VERSION)
+	# Extra sources referenced by the specs (rtw89-kmod.spec Source1).
+	cp -f ../rtw89.conf ~/rpmbuild/SOURCES/
+
+check-kmod-deps:
+	@for i in $(KMOD_REQUIRED_PKGS); do \
+		rpm -q $$i >/dev/null || { \
+			printf "Missing '%s', install with:\n\tsudo dnf install %s\n" "$$i" "$(KMOD_REQUIRED_PKGS)"; \
+			exit 1; \
+		}; \
+	done
+
+check-dkms-deps:
+	@for i in $(DKMS_REQUIRED_PKGS); do \
+		rpm -q $$i >/dev/null || { \
+			printf "Missing '%s', install with:\n\tsudo dnf install %s\n" "$$i" "$(DKMS_REQUIRED_PKGS)"; \
+			exit 1; \
+		}; \
+	done
+
+# ---------------------------------------------------------------------------
+# akmod: recommended for Fedora Kinoite / Silverblue. Produces noarch
+# rtw89-kmod-common + akmod-rtw89 (+ kmod-rtw89 meta). Modules build on the
+# target via akmods (ostree %post or akmods.service).
+# ---------------------------------------------------------------------------
+akmod: check-kmod-deps tarball
+	# The akmod %install re-runs rpmbuild -bs against %{_specdir}/%{name}.spec,
+	# so the spec must live in ~/rpmbuild/SPECS/.
+	cp -f rtw89-kmod.spec ~/rpmbuild/SPECS/
+	rpmbuild -ba \
+		--define "kmod_version $(VERSION)" \
+		--define "buildforkernels akmod" \
+		~/rpmbuild/SPECS/rtw89-kmod.spec
+	@printf '\nBuilt akmod packages in ~/rpmbuild/RPMS/.\n'
+	@printf 'On Fedora Kinoite install with:\n'
+	@printf '\tsudo rpm-ostree install \\\n'
+	@printf '\t  ~/rpmbuild/RPMS/$(shell uname -m)/akmod-rtw89-*.$(shell uname -m).rpm \\\n'
+	@printf '\t  ~/rpmbuild/RPMS/noarch/rtw89-kmod-common-*.noarch.rpm \\\n'
+	@printf '\t  kernel-devel\n'
+	@printf 'then reboot.\n\n'
+
+# ---------------------------------------------------------------------------
+# kmod: build a binary kmod-rtw89-<kver> for the kernel-devel present now.
+# Tied to one kernel version; useful for traditional (mutable) systems.
+# ---------------------------------------------------------------------------
+kmod: check-kmod-deps tarball
+	rpmbuild -ba \
+		--define "kmod_version $(VERSION)" \
+		--define "buildforkernels current" \
+		rtw89-kmod.spec
+	@printf '\nBuilt binary kmod packages in ~/rpmbuild/RPMS/$(shell uname -m)/.\n\n'
+
+# ---------------------------------------------------------------------------
+# dkms: legacy DKMS package. NOTE: does not work on immutable / rpm-ostree
+# systems because DKMS cannot install modules into the read-only /usr.
+# ---------------------------------------------------------------------------
+dkms: check-dkms-deps tarball
 	rpmbuild -ba --define "dkms_version $(VERSION)" rtw89-dkms.spec
 	@printf '\nNow run sudo dnf install ~/rpmbuild/RPMS/noarch/rtw89-dkms-*.noarch.rpm\n\n'

--- a/fedora/README.md
+++ b/fedora/README.md
@@ -1,42 +1,96 @@
-# RTW89 Fedora DKMS package
+# RTW89 Fedora packages
 
-This was created with the assistance of Claude Opus 4.6.
+Two packaging methods are provided:
 
-## Summary of what was created
+| Method | Spec | Works on Kinoite/Silverblue? | Notes |
+|--------|------|------------------------------|-------|
+| **akmod** (recommended) | `rtw89-kmod.spec` | **Yes** | Built via `kmodtool`/`akmods`. Modules are rebuilt on the target for every kernel. |
+| DKMS (legacy) | `rtw89-dkms.spec` | No | DKMS cannot install modules into the read-only `/usr` of an immutable OS. |
 
-- [rtw89-dkms.spec](rtw89-dkms.spec).
+On immutable / rpm-ostree systems (Fedora Kinoite, Silverblue, Bluefin, ...)
+DKMS does not work because it tries to copy the built `*.ko` into
+`/lib/modules/<kver>/extra/`, which lives under the read-only `/usr`. The
+official replacement is `akmods`, which is what the akmod package below uses.
 
-## What the package installs:
+## What the akmod packages install
 
-| Path                       | Content                                 |
-|----------------------------|-----------------------------------------|
-| /usr/src/rtw89-7.1/        | 102 source files + Makefile + dkms.conf |
-| /etc/modprobe.d/rtw89.conf | blacklists + driver options             |
+| Package | Arch | Content |
+|---------|------|---------|
+| `akmod-rtw89` | arch | Source SRPM in `/usr/src/akmods/` + akmods trigger |
+| `rtw89-kmod-common` | noarch | `/etc/modprobe.d/rtw89.conf` (blacklists + options) |
+| `kmod-rtw89` | arch | Metapackage tracking the newest kernel |
 
-## Install
+On rpm-ostree, `akmod-rtw89`'s `%post` calls `akmods-ostree-post`, which builds
+the modules for every deployed kernel and bakes the resulting `*.ko` into the
+new ostree commit's `/usr/lib/modules/<kver>/extra/rtw89/`. On traditional
+systems `akmods.service` rebuilds them on boot / kernel update instead.
 
-First install the dependencies to build the rpm package:
+## Build (in a Fedora toolbox or any Fedora host)
 
-```bash
-sudo dnf install rpmdevtools make git-core kernel-devel-matched
-```
-
-Then (re)build the package:
-
-```bash
-rm -fv ~/rpmbuild/RPMS/noarch/rtw89-dkms-*.noarch.rpm ~/rpmbuild/SRPMS/rtw89-dkms-*.src.rpm
-make
-sudo dnf install ~/rpmbuild/RPMS/noarch/rtw89-dkms-*.noarch.rpm
-```
-
-Verify it worked:
+Install build dependencies:
 
 ```bash
-dkms status   # verify: rtw89/7.1, $(uname -r), $(uname -m): installed
+sudo dnf install rpmdevtools make git-core kmodtool akmods kernel-devel-matched
 ```
 
-Check if the git commit got embedded properly:
+Build the akmod packages:
 
 ```bash
-xzcat /usr/lib/modules/$(uname -r)/extra/rtw89_core_git.ko.xz | grep -a "git commit"
+make            # or: make akmod
 ```
+
+The RPMs land in `~/rpmbuild/RPMS/`.
+
+## Install on Fedora Kinoite / Silverblue (rpm-ostree)
+
+`kernel-devel` must be layered so akmods can compile against the kernel.
+
+```bash
+sudo rpm-ostree install \
+  ~/rpmbuild/RPMS/$(uname -m)/akmod-rtw89-*.$(uname -m).rpm \
+  ~/rpmbuild/RPMS/noarch/rtw89-kmod-common-*.noarch.rpm \
+  kernel-devel
+systemctl reboot
+```
+
+After reboot, verify the modules were baked into the deployment:
+
+```bash
+ls /usr/lib/modules/$(uname -r)/extra/rtw89/
+modinfo rtw89_core_git | head
+# check the embedded git commit:
+modinfo rtw89_core_git | grep -iE 'git|version'
+```
+
+## Install on a traditional (mutable) Fedora Workstation
+
+```bash
+sudo dnf install \
+  ~/rpmbuild/RPMS/$(uname -m)/akmod-rtw89-*.$(uname -m).rpm \
+  ~/rpmbuild/RPMS/noarch/rtw89-kmod-common-*.noarch.rpm
+# akmods builds on next boot, or trigger it now:
+sudo akmods --force
+```
+
+## Secure Boot
+
+If Secure Boot is enabled, the akmods-signed modules need their MOK enrolled:
+
+```bash
+sudo kmodgenca -a
+sudo mokutil --import /etc/pki/akmods/certs/public_key.der
+# reboot and complete enrollment in the MOK manager
+```
+
+## Other build targets
+
+```bash
+make akmod      # akmod packages (default, recommended)
+make kmod       # binary kmod-rtw89-<kver> for the current kernel-devel
+make dkms       # legacy DKMS package (does NOT work on rpm-ostree)
+```
+
+---
+
+The DKMS path is documented for completeness only; on Kinoite use the akmod
+packages above.

--- a/fedora/rtw89-kmod.spec
+++ b/fedora/rtw89-kmod.spec
@@ -1,0 +1,127 @@
+# rtw89 out-of-tree kernel modules, packaged the RPM Fusion "kmod" way so it
+# works on immutable / rpm-ostree systems (Fedora Kinoite, Silverblue, ...)
+# through akmods.
+#
+# Building this SRPM produces (by default, buildforkernels=akmod):
+#   * rtw89-kmod-common  - noarch, the modprobe blacklist/options config.
+#   * akmod-rtw89        - the source + akmods trigger. On rpm-ostree its %post
+#                          runs akmods-ostree-post, which builds the modules for
+#                          every deployed kernel and bakes the resulting *.ko
+#                          into the new ostree commit's
+#                          /usr/lib/modules/<kver>/extra/rtw89/. On traditional
+#                          systems akmods.service rebuilds on boot / kernel
+#                          update instead.
+#   * kmod-rtw89         - metapackage tracking the newest kernel.
+#
+# Pass --define "buildforkernels current" (or "newest") to instead build a
+# binary kmod-rtw89-<kver> for the kernel-devel present at build time.
+
+%global kmod_name rtw89
+
+# These out-of-tree modules carry no useful debuginfo for end users and the
+# kmod packaging does not ship a debugsource list; disable debug packaging.
+%global debug_package %{nil}
+
+# akmod (default) | current | newest
+%{!?buildforkernels: %global buildforkernels akmod}
+
+# Upstream version (sourced from dkms.conf via fedora/Makefile --define).
+%{!?kmod_version: %global kmod_version 7.2}
+
+Name:           %{kmod_name}-kmod
+Version:        %{kmod_version}
+Release:        1%{?dist}
+Summary:        Out-of-tree kernel modules for Realtek rtw89 WiFi chips
+License:        GPL-2.0-only OR BSD-3-Clause
+URL:            https://github.com/morrownr/rtw89
+Source0:        %{kmod_name}-%{kmod_version}.tar.gz
+Source1:        %{kmod_name}.conf
+
+BuildRequires:  kmodtool
+BuildRequires:  gcc
+BuildRequires:  make
+%{?AkmodsBuildRequires:BuildRequires: %{AkmodsBuildRequires}}
+
+# When building binary kmods (buildforkernels != akmod) we target the kernels
+# whose kernel-devel is installed; for akmod we must NOT pass --for-kernels.
+%if "%{buildforkernels}" != "akmod"
+%{!?kernels:%global kernels %(ls /usr/src/kernels 2>/dev/null)}
+%endif
+
+# Let kmodtool generate the kmod / akmod / meta subpackages and macros.
+# - akmod mode: --akmod, no --for-kernels -> akmod-rtw89 + kmod-rtw89 meta.
+# - otherwise : --for-kernels "<kvers>"   -> binary kmod-rtw89-<kver>.
+%{expand:%(kmodtool --target %{_target_cpu} --repo %{kmod_name} --kmodname %{name} %{?kernels:--for-kernels "%{?kernels}"}%{!?kernels:--%{buildforkernels}} 2>/dev/null) }
+
+# --- common subpackage: shared modprobe config -----------------------------
+%package -n %{kmod_name}-kmod-common
+Summary:        Common files for the rtw89 kernel modules
+BuildArch:      noarch
+
+%description -n %{kmod_name}-kmod-common
+Shared files for the out-of-tree rtw89 kernel modules: modprobe blacklist
+rules that suppress the in-kernel rtw89 driver plus default module options.
+
+%files -n %{kmod_name}-kmod-common
+%config(noreplace) %{_sysconfdir}/modprobe.d/%{kmod_name}.conf
+# ---------------------------------------------------------------------------
+
+%description
+Out-of-tree kernel modules for Realtek rtw89-series WiFi adapters
+(RTW8851B, RTW8852A/B/BT/C, RTW8922A and their USB/PCIe variants).
+
+Module names carry a _git suffix (e.g. rtw89_core_git) to avoid clashing
+with the in-kernel rtw89 driver. Blacklist rules in /etc/modprobe.d/ suppress
+the in-kernel modules so only this driver loads.
+
+%prep
+# kmodtool sanity check (errors out via %{kmodtool_check} if any).
+%{?kmodtool_check}
+
+# Print kmodtool's view for the build log (debugging aid).
+kmodtool --target %{_target_cpu} --repo %{kmod_name} --kmodname %{name} %{?kernels:--for-kernels "%{?kernels}"}%{!?kernels:--%{buildforkernels}} 2>/dev/null
+
+# Unpack Source0 (rtw89-%{version}/...) without a top create dir clobber.
+%setup -q -c -T -a 0
+
+# kmodtool builds one tree per kernel variant in _kmod_build_<kver>.
+for kernel_version in %{?kernel_versions} ; do
+    cp -a %{kmod_name}-%{version} _kmod_build_${kernel_version%%___*}
+done
+
+%build
+for kernel_version in %{?kernel_versions} ; do
+    make -C "${kernel_version##*___}" M="${PWD}/_kmod_build_${kernel_version%%___*}" \
+        KVER="${kernel_version%%___*}" KDIR="${kernel_version##*___}" modules
+done
+
+# Number of modules the driver Makefile is expected to produce (21: core +
+# per-chip + per-bus variants). Guards against silent packaging drift if the
+# upstream Makefile gains/loses an obj-m target.
+%global expected_modules 21
+
+%install
+for kernel_version in %{?kernel_versions} ; do
+    builddir="_kmod_build_${kernel_version%%___*}"
+    # Fail loudly if the build produced an unexpected module set (uncompressed
+    # *.ko at this point; kmodtool's __spec_install_post does the xz later).
+    n=$(find "${builddir}" -maxdepth 1 -name '*.ko' | wc -l)
+    if [ "${n}" -ne "%{expected_modules}" ]; then
+        echo "ERROR: built ${n} modules, expected %{expected_modules} for ${kernel_version%%___*}" >&2
+        exit 1
+    fi
+    install -d "%{buildroot}%{kmodinstdir_prefix}${kernel_version%%___*}%{kmodinstdir_postfix}"
+    install -m 0755 "${builddir}"/*.ko \
+        "%{buildroot}%{kmodinstdir_prefix}${kernel_version%%___*}%{kmodinstdir_postfix}"
+done
+
+# In akmod mode, drop the SRPM into /usr/src/akmods/ (kmodtool macro).
+%{?akmod_install}
+
+# Common subpackage payload.
+install -Dm 0644 %{SOURCE1} %{buildroot}%{_sysconfdir}/modprobe.d/%{kmod_name}.conf
+
+%changelog
+* Tue Jun 30 2026 jim60105 - 7.2-1
+- Initial kmod/akmod package based on morrownr/rtw89 version 7.2.
+- Works on immutable / rpm-ostree systems (Fedora Kinoite) via akmods.


### PR DESCRIPTION
**Human tested and confirmed working on my host system: Fedora Kinoite 43
(`43.20260629.0`, kernel `7.0.13-100.fc43.x86_64`).**

## Summary

Adds an `akmods`-based packaging path so the `rtw89` driver can be installed on
immutable / rpm-ostree systems (Fedora Kinoite, Silverblue, Bluefin, ...), where
the existing DKMS package cannot work. The legacy DKMS package is left
completely unchanged for traditional mutable systems.

The root problem: installing out-of-tree modules ultimately copies `*.ko` into
`/lib/modules/<kver>/extra/`, which lives under the **read-only** `/usr` on an
immutable OS. DKMS builds and signs the modules but cannot write them there, so
the driver never lands in the deployment. The officially recommended replacement
on immutable Fedora is `akmods`, which this PR uses.

## Changes

- **New `fedora/rtw89-kmod.spec`** built on the `kmodtool`/`akmods` framework.
  By default (`buildforkernels=akmod`) it produces:
  - `akmod-rtw89` — ships the source SRPM under `/usr/src/akmods/`; its `%post`
    runs `akmods-ostree-post`, which builds the modules for every deployed
    kernel and bakes the resulting `*.ko` into the **new ostree commit's**
    `/usr/lib/modules/<kver>/extra/rtw89/`.
  - `rtw89-kmod-common` (noarch) — `/etc/modprobe.d/rtw89.conf` (blacklists +
    module options), required by both the kmod and akmod packages.
  - `kmod-rtw89` — metapackage tracking the newest kernel.
  - Pass `--define "buildforkernels current"` to instead build a binary
    `kmod-rtw89-<kver>` for the kernel-devel present at build time (traditional
    systems).
- Assert the expected module count (**21**) at build time to guard against
  silent packaging drift if the upstream Makefile gains/loses an `obj-m` target.
- Disable `debug_package` (the out-of-tree modules ship no debugsource).
- **Refactor `fedora/Makefile`**: extract a shared `tarball` target and add
  `akmod` (default), `kmod`, and `dkms` targets, each with its own dependency
  check. The legacy DKMS package and its behavior are unchanged.
- **Rewrite `fedora/README.md`** to document the akmod path as recommended for
  Kinoite/Silverblue, keeping the DKMS path for traditional systems only.

## Testing

**Tested and confirmed working on my host system: Fedora Kinoite 43
(`43.20260629.0`, kernel `7.0.13-100.fc43.x86_64`).** Built inside a Fedora 43
toolbox; installed on the live Kinoite host via:

```bash
sudo rpm-ostree install \
  ~/rpmbuild/RPMS/$(uname -m)/akmod-rtw89-*.$(uname -m).rpm \
  ~/rpmbuild/RPMS/noarch/rtw89-kmod-common-*.noarch.rpm \
  kernel-devel
```

`rpm-ostree install` completed successfully — `akmods-ostree-post` built the
modules during the compose and baked them into the new deployment. After reboot
the `rtw89_*_git` modules are present in `/usr/lib/modules/<kver>/extra/rtw89/`
and load/bind to the device.

Additional verification:

- `make akmod` produces all three RPMs; the embedded SRPM has the correct
  `GIT_COMMIT` hash baked into the driver Makefile.
- `akmodsbuild` against the embedded SRPM compiles all 21 modules, signs and
  `xz`-compresses them into `/lib/modules/<kver>/extra/rtw89/` (exit 0).
- `depmod` on the built modules generates 80 device aliases (PCI/USB IDs)
  correctly pointing at the renamed `rtw89_*_git` modules, confirming the
  rename + blacklist strategy still autoloads/binds the device.
- `make kmod` (binary kmod path) and `make dkms` (legacy, unchanged) both build
  successfully.

## Notes

- On rpm-ostree, `kernel-devel` must be layered alongside the akmod packages so
  akmods can compile against the kernel. This is documented in
  `fedora/README.md`.
- If Secure Boot is enabled, the akmods signing key must be enrolled via MOK
  (documented in the README). My host has Secure Boot disabled, so unsigned
  modules load directly.
